### PR TITLE
Update server.lua to fix Warn

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -325,11 +325,11 @@ RegisterCommand("warn", function(source, args, rawCommand)	-- /warn [ID] , will 
 								local warnCount = warnedPlayers[targetId] or 1
 								if warnCount >= Config.warnMax then
 									DropPlayer(targetId, _U('warnkick'))
-									TriggerClientEvent("chatMessage", xPlayer.source, _U('playerkicked', args[1], warnCount, Config.warnMa))
+									TriggerClientEvent("chatMessage", xPlayer.source, _U('playerkicked', args[1], warnCount, Config.warnMax))
 									warnedPlayers[targetId] = nil
 								else
-									TriggerClientEvent("chatMessage", xPlayer.source, _U('playerwarned', args[1], warnCount, Config.warnMa))
-									TriggerClientEvent("chatMessage", xTarget.source, _U('gotwarn', warnCount, Config.warnMa))
+									TriggerClientEvent("chatMessage", xPlayer.source, _U('playerwarned', args[1], warnCount, Config.warnMax))
+									TriggerClientEvent("chatMessage", xTarget.source, _U('gotwarn', warnCount, Config.warnMax))
 									warnedPlayers[targetId] = warnCount + 1
 								end
 							end


### PR DESCRIPTION
When giving someone a warning, it shows up in chat as [1/nil]. This should now fix it to show [1/3] for example. Due to a typo, it wasn't recognizing the defined Config.